### PR TITLE
Add basic Laravel skeleton with Git-FTP page

### DIFF
--- a/laravel-app/README.md
+++ b/laravel-app/README.md
@@ -1,0 +1,5 @@
+# Laravel Git-FTP Skeleton
+
+Este es un esqueleto de proyecto que ilustra la estructura básica para un servicio de Git-FTP.
+
+Debido a las limitaciones del entorno actual, no se ejecutó `composer` ni `npm` para instalar Laravel, Jetstream o Vue. Se recomienda ejecutar `composer install` y seguir la documentación oficial de Laravel para configurar un proyecto real.

--- a/laravel-app/app/Http/Controllers/GitFtpController.php
+++ b/laravel-app/app/Http/Controllers/GitFtpController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class GitFtpController extends Controller
+{
+    /**
+     * Display the Git-FTP service page.
+     */
+    public function index()
+    {
+        return view('gitftp');
+    }
+}

--- a/laravel-app/resources/views/gitftp.blade.php
+++ b/laravel-app/resources/views/gitftp.blade.php
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Git FTP</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss/dist/tailwind.min.css">
+</head>
+<body class="p-8">
+    <h1 class="text-2xl mb-4">Servicio Git-FTP</h1>
+    <form class="mb-4">
+        <label class="block">Ruta local del repositorio</label>
+        <input type="text" class="border p-2 w-full" placeholder="/ruta/a/proyecto" />
+    </form>
+
+    <div class="mb-4">
+        <label class="block">Selecciona una rama</label>
+        <select class="border p-2 w-full">
+            <option>main</option>
+            <!-- Otras ramas -->
+        </select>
+    </div>
+
+    <div class="mb-4">
+        <h2 class="text-xl">Cambios por subir</h2>
+        <ul class="list-disc ml-6">
+            <!-- Lista de archivos diferentes -->
+            <li>example.txt</li>
+        </ul>
+    </div>
+
+    <div>
+        <h2 class="text-xl">Configuraci&oacute;n FTP de la rama</h2>
+        <form>
+            <label class="block">FTP URL</label>
+            <input type="text" class="border p-2 w-full" placeholder="ftp://example.com" />
+        </form>
+    </div>
+</body>
+</html>

--- a/laravel-app/routes/web.php
+++ b/laravel-app/routes/web.php
@@ -1,0 +1,6 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\GitFtpController;
+
+Route::get('/git-ftp', [GitFtpController::class, 'index']);


### PR DESCRIPTION
## Summary
- bootstrap a minimal Laravel-like structure
- add `GitFtpController` and route
- add simple Tailwind-based view for the Git-FTP service
- document limitations and usage

## Testing
- `find laravel-app -maxdepth 4 -type f`


------
https://chatgpt.com/codex/tasks/task_b_68509b5dbf5c832991e8e18ed14c1191