### PR TITLE
Add modules overview in project editing

### DIFF
--- a/laravel-app/app/Http/Controllers/Admin/ProyectoController.php
+++ b/laravel-app/app/Http/Controllers/Admin/ProyectoController.php
@@ -41,7 +41,11 @@ class ProyectoController extends Controller
 
     public function edit(Proyecto $proyecto)
     {
-        return Inertia::render('Projects/Edit', ['proyecto' => $proyecto]);
+        $proyecto->load('modulos.submodulos.documentos.recursos');
+
+        return Inertia::render('Projects/Edit', [
+            'proyecto' => $proyecto,
+        ]);
     }
 
     public function update(Request $request, Proyecto $proyecto)

--- a/laravel-app/resources/js/Pages/Projects/Edit.vue
+++ b/laravel-app/resources/js/Pages/Projects/Edit.vue
@@ -55,6 +55,54 @@ const submit = () => {
                     </form>
                 </div>
             </div>
+            <div class="mt-8 bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <h3 class="text-lg font-semibold mb-4">Módulos</h3>
+                <div class="mb-2">
+                    <Link :href="route('admin.proyectos.modulos.create', proyecto.proyecto_id)" class="text-sm text-indigo-600 hover:underline">Nuevo módulo</Link>
+                </div>
+                <ul v-if="proyecto.modulos && proyecto.modulos.length" class="list-disc ml-5 space-y-4">
+                    <li v-for="modulo in proyecto.modulos" :key="modulo.modulo_id">
+                        <div class="font-semibold">{{ modulo.nombre }}</div>
+                        <p class="text-sm text-gray-600" v-if="modulo.descripcion">{{ modulo.descripcion }}</p>
+
+                        <ul v-if="modulo.submodulos && modulo.submodulos.length" class="list-disc ml-5 mt-2 space-y-2">
+                            <li v-for="sub in modulo.submodulos" :key="sub.submodulo_id">
+                                <div class="font-semibold">{{ sub.nombre }}</div>
+                                <p class="text-sm text-gray-600" v-if="sub.descripcion">{{ sub.descripcion }}</p>
+
+                                <ul v-if="sub.documentos && sub.documentos.length" class="list-decimal ml-5 mt-1 space-y-1">
+                                    <li v-for="doc in sub.documentos" :key="doc.documento_id">
+                                        <div class="font-semibold">{{ doc.titulo }}</div>
+                                        <p class="text-xs text-gray-600" v-if="doc.contenido">{{ doc.contenido }}</p>
+
+                                        <ul v-if="doc.recursos && doc.recursos.length" class="ml-4 list-disc mt-1 space-y-1">
+                                            <li v-for="recurso in doc.recursos" :key="recurso.recurso_id" class="text-xs">
+                                                <span class="font-medium">{{ recurso.tipo }}:</span>
+                                                <a :href="recurso.url" target="_blank" class="text-indigo-600 hover:underline ml-1">{{ recurso.url }}</a>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+
+                        <ul v-if="modulo.documentos && modulo.documentos.length" class="list-decimal ml-5 mt-2 space-y-1">
+                            <li v-for="doc in modulo.documentos" :key="doc.documento_id">
+                                <div class="font-semibold">{{ doc.titulo }}</div>
+                                <p class="text-xs text-gray-600" v-if="doc.contenido">{{ doc.contenido }}</p>
+
+                                <ul v-if="doc.recursos && doc.recursos.length" class="ml-4 list-disc mt-1 space-y-1">
+                                    <li v-for="recurso in doc.recursos" :key="recurso.recurso_id" class="text-xs">
+                                        <span class="font-medium">{{ recurso.tipo }}:</span>
+                                        <a :href="recurso.url" target="_blank" class="text-indigo-600 hover:underline ml-1">{{ recurso.url }}</a>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+                <div v-else class="text-sm text-gray-500">No hay módulos asociados.</div>
+            </div>
         </div>
     </AppLayout>
 </template>


### PR DESCRIPTION
## Summary
- load full module tree when editing projects
- show module, submodule, document, and resource hierarchy in project edit view

## Testing
- `npm run build` *(fails: vite not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853976ca8848329a78e0ba5610f254a